### PR TITLE
Quick Faceswap Build - Added build.sh script and fix PYTHONPATH for inference

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.png filter=lfs diff=lfs merge=lfs -text
+*.svg filter=lfs diff=lfs merge=lfs -text
+*.pth filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,6 @@ data
 
 flagged
 
-!pretrained_ckpts/auxiliray/model.pth
-
+pretrained_ckpts/auxiliray/model.pth
+*.png
 start.sh

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Please check the [installation Doc](./INSTALLATION.md) for the guidance.
 ### 2.1 face swapping 
 #### Face swapping in defult settings:
 ```sh
-python scripts/face_swap.py --source=example/input/faceswap/source.jpg --target=example/input/faceswap/target.jpg
+PYTHONPATH=. python scripts/face_swap.py --source=example/input/faceswap/source.jpg --target=example/input/faceswap/target.jpg
 ```
 The reuslts will be saved to `example/output/faceswap` folder. Left to right: source, target, swapped face
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+conda config --set channel_priority flexible
+conda env create -f e4s_env.yaml
+pip install gdown
+gdown 1cyJTYRO5G4kcugAcgSJ7cMsE96GzV_hq -O ./pretrained_ckpts/e4s/iteration_300000.pt
+gdown 154JgKpzCPW82qINcVieuPH3fZ2e0P812 -O ./pretrained_ckpts/face_parsing/79999_iter.pth
+gdown 1FJDN1edNpUyx8Bv5Eo7JutAvbL9zFfn4 -O ./pretrained_ckpts/face_parsing/segnext.small.best_mIoU_iter_140000.pth
+gdown 1YL4VuCBhhl-sjI3oPZOJhxTf9rIJRxD5 -O ./pretrained_ckpts/face_parsing/segnext.base.best_mIoU_iter_140000.pth
+curl -L -o ./pretrained_ckpts/facevid2vid/00000189-checkpoint.pth.tar "https://download940.mediafire.com/xkjogf9xeojgeXtYFplm5bCoFUHGoCkePfSQ5w3wLkzldJBcTeu3Pm5STboTYF0ZVFdrkS7yKF7pdtWvqamfunG_m4LylmUFin1jXiG657tfjCw05Qrq_vq2fQUprDD2Cr-Id-CtQ8KqhelOZlJT_pmJOMPijovDDI_omhYqrhpU7_0/f0utmig51dal20b/00000189-checkpoint.pth.tar"
+curl -L -o ./pretrained_ckpts/facevid2vid/vox-256-spade.yaml "https://download1327.mediafire.com/a7ro467mjvzgyGvE7lLtqoZG25K_1E9fKHd33JAeueq5FdNpPY_KkU62ibabqhUaPCS_Ax7Fh4vyA3vGayck2ZXO0mF11rReowM5GvOLyiAIeWhXW3qg_LIqoL1UAxHEaBsk7IzP5PgNcYrlOyYOPt0mfXRN6R6jB_t7lYjyJ7_pdGk/lpxqkxkktmnj129/vox-256-spade.yaml"
+cd pretrained_ckpts/gpen
+sh fetch_gepn_models.sh

--- a/e4s_env.yaml
+++ b/e4s_env.yaml
@@ -79,6 +79,7 @@ dependencies:
   - xz=5.2.10=h5eee18b_1
   - zlib=1.2.13=h5eee18b_0
   - zstd=1.5.4=hc292b87_0
+  - libstdcxx-ng-13.2.0
   - pip:
     - contourpy==1.0.7
     - cycler==0.11.0
@@ -105,5 +106,6 @@ dependencies:
     - tensorboardx==2.6
     - tifffile==2023.3.21
     - tqdm==4.65.0
+    - ninja-1.11.1.4
     - zipp==3.15.0
 prefix: /home/lza/miniconda3/envs/e4s

--- a/pretrained_ckpts/facevid2vid/vox-256-spade.yaml
+++ b/pretrained_ckpts/facevid2vid/vox-256-spade.yaml
@@ -1,0 +1,88 @@
+dataset_params:
+  root_dir: 
+  frame_shape: [256, 256, 3]
+  id_sampling: True
+  pairs_list: None
+  augmentation_params:
+    flip_param:
+      horizontal_flip: True
+      time_flip: True
+    jitter_param:
+      brightness: 0.1
+      contrast: 0.1
+      saturation: 0.1
+      hue: 0.1
+
+
+model_params:
+  common_params:
+    num_kp: 15 
+    image_channel: 3                    
+    feature_channel: 32
+    estimate_jacobian: False
+  kp_detector_params:
+     temperature: 0.1
+     block_expansion: 32            
+     max_features: 1024
+     scale_factor: 0.25
+     num_blocks: 5
+     reshape_channel: 16384  # 16384 = 1024 * 16
+     reshape_depth: 16
+  he_estimator_params:
+     block_expansion: 64            
+     max_features: 2048
+     num_bins: 66
+  generator_params:
+    block_expansion: 64
+    max_features: 512
+    num_down_blocks: 2
+    reshape_channel: 32
+    reshape_depth: 16         # 512 = 32 * 16
+    num_resblocks: 6
+    estimate_occlusion_map: True
+    dense_motion_params:
+      block_expansion: 32
+      max_features: 1024
+      num_blocks: 5
+      # reshape_channel: 32
+      reshape_depth: 16
+      compress: 4
+  discriminator_params:
+    scales: [1]
+    block_expansion: 32                 
+    max_features: 512
+    num_blocks: 4
+    sn: True
+
+train_params:
+  num_epochs: 200
+  num_repeats: 75
+  epoch_milestones: [180,]
+  lr_generator: 2.0e-4
+  lr_discriminator: 2.0e-4
+  lr_kp_detector: 2.0e-4
+  lr_he_estimator: 2.0e-4
+  gan_mode: 'hinge'    # hinge or ls
+  batch_size: 1
+  scales: [1, 0.5, 0.25, 0.125]
+  checkpoint_freq: 60
+  hopenet_snapshot: './checkpoints/hopenet_robust_alpha1.pkl'
+  transform_params:
+    sigma_affine: 0.05
+    sigma_tps: 0.005
+    points_tps: 5
+  loss_weights:
+    generator_gan: 1                  
+    discriminator_gan: 1
+    feature_matching: [10, 10, 10, 10]
+    perceptual: [10, 10, 10, 10, 10]
+    equivariance_value: 10
+    equivariance_jacobian: 0
+    keypoint: 10
+    headpose: 20
+    expression: 5
+
+visualizer_params:
+  kp_size: 5
+  draw_border: True
+  colormap: 'gist_rainbow'


### PR DESCRIPTION
- Added build.sh script to automate model collection and environment setup for face swap functionality.
- Updated inference command to include PYTHONPATH=. to resolve 'src' module import error.
- Renamed fetch_gpen_models.sh to fetch_gepn_models.sh
This PR adds a build.sh script to streamline environment setup and model collection. It also fixes an issue with the inference command by setting PYTHONPATH to the current directory to avoid module import errors. Let me know if anything needs to be changed. Thank you!